### PR TITLE
derivative calculation correction

### DIFF
--- a/Matlab/filter_GPETT2D.m
+++ b/Matlab/filter_GPETT2D.m
@@ -138,12 +138,12 @@ function [covMatrixDerivative] = compute_GP_covariance_derivative(argArray1, arg
 end
 
 % Numeric derivative for verification
-function [covMatrix] = compute_GP_covariance_derivative_numeric(argArray1, argArray2, paramGP, eps)
+function [covMatrixDerivative] = compute_GP_covariance_derivative_numeric(argArray1, argArray2, paramGP, eps)
     vec_len1 = size(argArray1, 1);
     vec_len2 = size(argArray2, 1);
-    covMatrix = zeros(vec_len1, vec_len2);
+    covMatrixDerivative = zeros(vec_len1, vec_len2);
     for i = 1:vec_len1
-        covMatrix(i, :) = (compute_GP_covariance(argArray1(i)+eps/2, argArray2, paramGP) ...
+        covMatrixDerivative(i, :) = (compute_GP_covariance(argArray1(i)+eps/2, argArray2, paramGP) ...
             - compute_GP_covariance(argArray1(i)-eps/2, argArray2, paramGP))/eps;
    end
 end


### PR DESCRIPTION
A minor miscalculation in derivatives is fixed. Because of the minor difference between the periodic kernels in the paper, i.e Eq. (23) and Eq. (25), the jacobian of measurement equation is calculated incorrectly. In Eq. (57e) the kernel in Eq. (23) is used not the kernel in Eq. (25). This PR fixes this issue. Credits to Ege Keyvan for pointing out the miscalculation.